### PR TITLE
Fix SPI pinout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,13 @@
 # User configuration section starts here
 
-# Default output data pin for the LED strip
+# Default output data pin for the non-SPI LED strips (only for sk6812/ws2812b)
 set(OUTPUT_DATA_PIN 2)
 
-# Default output clock pin for the LED strip (SPI leds only, not for sk6812/ws2812b)
-set(OUTPUT_CLOCK_PIN 3)
+# Default output data/clocks pin for the SPI LED strips (only for apa102, not for sk6812/ws2812b)
+# only certain pairs of pins are allowed for selected SPI interface (refer to "readme.md")
+set(OUTPUT_SPI_DATA_PIN 3)
+set(OUTPUT_SPI_CLOCK_PIN 2)
+set(SPI_INTERFACE spi0)
 
 # Use multi-segment, starting index of second led strip or OFF to disable
 set(SECOND_SEGMENT_INDEX OFF)
@@ -62,7 +65,7 @@ endmacro()
 # targets for different LED strips
 IF(NOT SECOND_SEGMENT_INDEX)
     HyperSerialPicoTarget("HyperSerialPico_Spi")
-    target_compile_definitions(HyperSerialPico_Spi PRIVATE -DSPILED_APA102 -DDATA_PIN=${OUTPUT_DATA_PIN} -DCLOCK_PIN=${OUTPUT_CLOCK_PIN})
+    target_compile_definitions(HyperSerialPico_Spi PRIVATE -DSPILED_APA102 -DSPI_INTERFACE=${SPI_INTERFACE} -DDATA_PIN=${OUTPUT_SPI_DATA_PIN} -DCLOCK_PIN=${OUTPUT_SPI_CLOCK_PIN})
     HyperSerialPicoTarget("HyperSerialPico_sk6812Cold")
     target_compile_definitions(HyperSerialPico_sk6812Cold PRIVATE -DNEOPIXEL_RGBW -DCOLD_WHITE -DDATA_PIN=${OUTPUT_DATA_PIN})
     HyperSerialPicoTarget("HyperSerialPico_sk6812Neutral")

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ You need HyperHDR v20 or newer. Make sure you have enabled `AWA protocol` and `E
 
 rp2040 allows hardware SPI on corresponding pairs of pins:  
 spi0 ⇒ Data/Clock: GPIO3/GPIO2, GPIO19/GPIO18, GPIO7/GPIO6  
-spi1 ⇒ Data/Clock: GPIO12/GPIO10, GPIO8/GPIO06, GPIO28/GPI26  
+spi1 ⇒ Data/Clock: GPIO11/GPIO10, GPI15/GPIO14, GPIO27/GPI26  
 
 Pinout can be changed, but you need to make changes to `CMakeList.txt` (e.g. `OUTPUT_DATA_PIN` / `OUTPUT_SPI_DATA_PIN` / `OUTPUT_SPI_CLOCK_PIN`) and recompile the project. Also multi-segment mode can be enabled in this file: `SECOND_SEGMENT_INDEX` option at the beginning and optionally `SECOND_SEGMENT_REVERSED`. Once compiled, the results can be found in the `firmwares` folder.  
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ In the system file explorer you should find new drive (e.g. called `RPI-RP2` dri
 The Pico will reset automaticly after the upload and after few seconds it will be ready to use by HyperHDR as a serial port device using Adalight driver.
 
 # HyperHDR configuration
-You need HyperHDR v20 or newer. Make sure you have enabled `AWA protocol` and `Esp8266/ESP32/Rp2040 handshake` options.  
-You can leave the speed at `2000000` because the CDC driver should use the highest possible speed automatically (at least it happens on Windows).  
+You need HyperHDR v20 or newer. Make sure you have enabled `AWA protocol` and `Esp8266/ESP32/Rp2040 handshake` options. You can leave the speed at `2000000` because the CDC driver should use the highest possible speed automatically (at least it happens on Windows).  
+
 ![obraz](https://user-images.githubusercontent.com/69086569/236870662-12f67d14-c2ca-4ba1-b6a3-e34c27949d19.png)
 
 # Default pinout
@@ -42,8 +42,7 @@ rp2040 allows hardware SPI on corresponding pairs of pins:
 spi0 ⇒ Data/Clock: GPIO3/GPIO2, GPIO19/GPIO18, GPIO7/GPIO6  
 spi1 ⇒ Data/Clock: GPIO12/GPIO10, GPIO8/GPIO06, GPIO28/GPI26  
 
-Pinout can be changed, but you need to make changes to `CMakeList.txt` (e.g. `OUTPUT_DATA_PIN`/`OUTPUT_SPI_DATA_PIN`/`OUTPUT_SPI_CLOCK_PIN`) and recompile the project. Also multi-segment mode can be enabled in this file: `SECOND_SEGMENT_INDEX` option at the beginning and optionally `SECOND_SEGMENT_REVERSED`.  
-Once compiled, the results can be found in the `firmwares` folder.  
+Pinout can be changed, but you need to make changes to `CMakeList.txt` (e.g. `OUTPUT_DATA_PIN` / `OUTPUT_SPI_DATA_PIN` / `OUTPUT_SPI_CLOCK_PIN`) and recompile the project. Also multi-segment mode can be enabled in this file: `SECOND_SEGMENT_INDEX` option at the beginning and optionally `SECOND_SEGMENT_REVERSED`. Once compiled, the results can be found in the `firmwares` folder.  
 
 # Some benchmark results
 

--- a/README.md
+++ b/README.md
@@ -29,16 +29,20 @@ In the system file explorer you should find new drive (e.g. called `RPI-RP2` dri
 The Pico will reset automaticly after the upload and after few seconds it will be ready to use by HyperHDR as a serial port device using Adalight driver.
 
 # HyperHDR configuration
-Make sure you have enabled `AWA protocol` and `Esp8266/ESP32/Rp2040 handshake` options.  
+You need HyperHDR v20 or newer. Make sure you have enabled `AWA protocol` and `Esp8266/ESP32/Rp2040 handshake` options.  
 You can leave the speed at `2000000` because the CDC driver should use the highest possible speed automatically (at least it happens on Windows).  
 ![obraz](https://user-images.githubusercontent.com/69086569/236870662-12f67d14-c2ca-4ba1-b6a3-e34c27949d19.png)
 
 # Default pinout
   
 **LED output (SK6812/WS281x):** GPIO2 for Data    
-**LED output (SPI LEDs):** GPIO2 for Data, GPIO3 for Clock  
+**LED output (SPI LEDs):** GPIO3 for Data, GPIO2 for Clock  
 
-Pinout can be changed, but you need to make changes to CMakeList.txt (`OUTPUT_DATA_PIN`/`OUTPUT_CLOCK_PIN`) and recompile the project. Also multi-segment mode can be enabled in this file: `SECOND_SEGMENT_INDEX` option at the beginning and optionally `SECOND_SEGMENT_REVERSED`.  
+rp2040 allows hardware SPI on corresponding pairs of pins:  
+spi0 ⇒ Data/Clock: GPIO3/GPIO2, GPIO19/GPIO18, GPIO7/GPIO6  
+spi1 ⇒ Data/Clock: GPIO12/GPIO10, GPIO8/GPIO06, GPIO28/GPI26  
+
+Pinout can be changed, but you need to make changes to `CMakeList.txt` (e.g. `OUTPUT_DATA_PIN`/`OUTPUT_SPI_DATA_PIN`/`OUTPUT_SPI_CLOCK_PIN`) and recompile the project. Also multi-segment mode can be enabled in this file: `SECOND_SEGMENT_INDEX` option at the beginning and optionally `SECOND_SEGMENT_REVERSED`.  
 Once compiled, the results can be found in the `firmwares` folder.  
 
 # Some benchmark results

--- a/include/base.h
+++ b/include/base.h
@@ -104,7 +104,7 @@ class Base
 				#if defined(NEOPIXEL_RGBW) || defined(NEOPIXEL_RGB)
 					ledStrip1 = new LED_DRIVER(ledsNumber, DATA_PIN);
 				#else
-					ledStrip1 = new LED_DRIVER(ledsNumber, DATA_PIN, CLOCK_PIN);
+					ledStrip1 = new LED_DRIVER(ledsNumber, SPI_INTERFACE, DATA_PIN, CLOCK_PIN);
 				#endif
 			}
 		}

--- a/include/leds.h
+++ b/include/leds.h
@@ -481,13 +481,13 @@ class Dotstar : public LedDriver, public DmaClient
     friend class NeopixelParallel;
 
     public:
-    Dotstar(uint64_t _resetTime, int _ledsNumber, uint32_t _datapin, uint32_t _clockpin, int _dmaSize):
+    Dotstar(uint64_t _resetTime, int _ledsNumber, spi_inst_t* _spi, uint32_t _datapin, uint32_t _clockpin, int _dmaSize):
             LedDriver(_ledsNumber, _datapin, _clockpin, _dmaSize)
     {
         dmaConfigure(pio0, 0);
         resetTime = _resetTime;
 
-        spi_init(spi_default, 10000000);
+        spi_init(_spi, 10000000);
         gpio_set_function(PICO_DEFAULT_SPI_RX_PIN, GPIO_FUNC_SPI);
         gpio_init(PICO_DEFAULT_SPI_CSN_PIN);
         gpio_set_function(_clockpin, GPIO_FUNC_SPI);
@@ -527,7 +527,8 @@ class DotstarType : public Dotstar
 {
     public:
 
-    DotstarType(int _ledsNumber, int _dataPin, int _clockPin) : Dotstar(RESET_TIME, _ledsNumber, _dataPin, _clockPin, (_ledsNumber + 2) * sizeof(colorData))
+    DotstarType(int _ledsNumber, spi_inst_t* _spi, int _dataPin, int _clockPin) : 
+        Dotstar(RESET_TIME, _ledsNumber, _spi, _dataPin, _clockPin, (_ledsNumber + 2) * sizeof(colorData))
     {
     }
 

--- a/include/leds.h
+++ b/include/leds.h
@@ -246,12 +246,12 @@ class DmaClient
         assignDmaIrq();
     };
 
-    void initDmaSpi(uint dataLenByte8)
+    void initDmaSpi(spi_inst_t* _spi, uint dataLenByte8)
     {
         dma_channel_config dmaConfig = dma_channel_get_default_config(PICO_DMA_CHANNEL);
         channel_config_set_transfer_data_size(&dmaConfig, DMA_SIZE_8);
-        channel_config_set_dreq(&dmaConfig, spi_get_dreq(spi_default, true));
-        dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig,&spi_get_hw(spi_default)->dr, NULL, dataLenByte8, false);
+        channel_config_set_dreq(&dmaConfig, spi_get_dreq(_spi, true));
+        dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig,&spi_get_hw(_spi)->dr, NULL, dataLenByte8, false);
 
         assignDmaIrq();
     };
@@ -487,15 +487,12 @@ class Dotstar : public LedDriver, public DmaClient
         dmaConfigure(pio0, 0);
         resetTime = _resetTime;
 
-        spi_init(_spi, 10000000);
-        gpio_set_function(PICO_DEFAULT_SPI_RX_PIN, GPIO_FUNC_SPI);
-        gpio_init(PICO_DEFAULT_SPI_CSN_PIN);
+        spi_init(_spi, 10000000);        
         gpio_set_function(_clockpin, GPIO_FUNC_SPI);
         gpio_set_function(_datapin, GPIO_FUNC_SPI);
-        bi_decl(bi_3pins_with_func(PICO_DEFAULT_SPI_RX_PIN, _datapin, _clockpin, GPIO_FUNC_SPI));
-        bi_decl(bi_1pin_with_name(PICO_DEFAULT_SPI_CSN_PIN, "SPI CS"));
+        bi_decl(bi_4pins_with_func(PICO_DEFAULT_SPI_RX_PIN, _datapin, _clockpin, PICO_DEFAULT_SPI_CSN_PIN, GPIO_FUNC_SPI));
 
-        initDmaSpi(_dmaSize);
+        initDmaSpi(_spi, _dmaSize);
     }
 
     uint8_t* getBufferMemory()

--- a/include/leds.h
+++ b/include/leds.h
@@ -28,43 +28,43 @@
  */
 
 /*
-    HyperSerialPico led (aka PicoLada) library features:
-    - neopixel (rgb: ws2812b, ws2813..., rgbw: sk6812b) and dotstar (rgb: apa102, hd107, sk9822...) led strip support
-    - single and up to 8 lines parallel (neopixel) mode
-    - DMA
-    - PIO neopixel hardware processing
-    - using LUT tables for preparing PIO DMA parallel buffer
-    - SPI dotstar hardware support
-    - non-blocking rendering (check isReady if it's finished)
+	HyperSerialPico led (aka PicoLada) library features:
+	- neopixel (rgb: ws2812b, ws2813..., rgbw: sk6812b) and dotstar (rgb: apa102, hd107, sk9822...) led strip support
+	- single and up to 8 lines parallel (neopixel) mode
+	- DMA
+	- PIO neopixel hardware processing
+	- using LUT tables for preparing PIO DMA parallel buffer
+	- SPI dotstar hardware support
+	- non-blocking rendering (check isReady if it's finished)
 
-    Usage for sk6812 rgbw single lane:
-    ledStrip1 = new sk6812(ledsNumber, DATA_PIN);
-    ledStrip1->SetPixel(index, ColorGrbw(255));
-    ledStrip1->renderSingleLane();
+	Usage for sk6812 rgbw single lane:
+	ledStrip1 = new sk6812(ledsNumber, DATA_PIN);
+	ledStrip1->SetPixel(index, ColorGrbw(255));
+	ledStrip1->renderSingleLane();
 
-    Usage for ws2812 rgb single lane:
-    ledStrip1 = new ws2812(ledsNumber, DATA_PIN);
-    ledStrip1->SetPixel(index, ColorGrb32(255));
-    ledStrip1->renderSingleLane();
+	Usage for ws2812 rgb single lane:
+	ledStrip1 = new ws2812(ledsNumber, DATA_PIN);
+	ledStrip1->SetPixel(index, ColorGrb32(255));
+	ledStrip1->renderSingleLane();
 
-    Usage for sk6812 rgbw multi lanes:
-    ledStrip1 = new sk6812p(ledsNumber, DATA_PIN); // using DATA_PIN output
-    ledStrip2 = new sk6812p(ledsNumber, DATA_PIN); // using DATA_PIN + 1 output
-    ledStrip1->SetPixel(index, ColorGrbw(255));
-    ledStrip2->SetPixel(index, ColorGrbw(255));
-    ledStrip1->renderAllLanes(); // renders ledStrip1 and ledStrip2 simoultaneusly
+	Usage for sk6812 rgbw multi lanes:
+	ledStrip1 = new sk6812p(ledsNumber, DATA_PIN); // using DATA_PIN output
+	ledStrip2 = new sk6812p(ledsNumber, DATA_PIN); // using DATA_PIN + 1 output
+	ledStrip1->SetPixel(index, ColorGrbw(255));
+	ledStrip2->SetPixel(index, ColorGrbw(255));
+	ledStrip1->renderAllLanes(); // renders ledStrip1 and ledStrip2 simoultaneusly
 
-    Usage for ws2812 rgb multi lanes:
-    ledStrip1 = new ws2812p(ledsNumber, DATA_PIN); // using DATA_PIN output
-    ledStrip2 = new ws2812p(ledsNumber, DATA_PIN); // using DATA_PIN + 1 output
-    ledStrip1->SetPixel(index, ColorGrb(255));
-    ledStrip2->SetPixel(index, ColorGrb(255));
-    ledStrip1->renderAllLanes(); // renders ledStrip1 and ledStrip2 simoultaneusly
+	Usage for ws2812 rgb multi lanes:
+	ledStrip1 = new ws2812p(ledsNumber, DATA_PIN); // using DATA_PIN output
+	ledStrip2 = new ws2812p(ledsNumber, DATA_PIN); // using DATA_PIN + 1 output
+	ledStrip1->SetPixel(index, ColorGrb(255));
+	ledStrip2->SetPixel(index, ColorGrb(255));
+	ledStrip1->renderAllLanes(); // renders ledStrip1 and ledStrip2 simoultaneusly
 
-    Usage for dotstar rgb single line:
-    ledStrip1 = new apa102(ledsNumber, DATA_PIN, CLOCK_PIN);
-    ledStrip1->SetPixel(index, ColorDotstartBgr(255));
-    ledStrip1->renderSingleLane();
+	Usage for dotstar rgb single line:
+	ledStrip1 = new apa102(ledsNumber, DATA_PIN, CLOCK_PIN);
+	ledStrip1->SetPixel(index, ColorDotstartBgr(255));
+	ledStrip1->renderSingleLane();
 */
 
 #include <hardware/spi.h>
@@ -78,471 +78,471 @@
 
 struct ColorGrb32
 {
-    uint8_t notUsed;
-    uint8_t B;
-    uint8_t R;
-    uint8_t G;
+	uint8_t notUsed;
+	uint8_t B;
+	uint8_t R;
+	uint8_t G;
 
-    ColorGrb32(uint8_t gray) :
-        R(gray), G(gray), B(gray)
-    {
-    };
+	ColorGrb32(uint8_t gray) :
+		R(gray), G(gray), B(gray)
+	{
+	};
 
-    ColorGrb32() : R(0), G(0), B(0)
-    {
-    };
+	ColorGrb32() : R(0), G(0), B(0)
+	{
+	};
 
-    static bool isAlignedTo24()
-    {
-        return true;
-    };
+	static bool isAlignedTo24()
+	{
+		return true;
+	};
 };
 
 struct ColorGrb
 {
-    uint8_t B;
-    uint8_t R;
-    uint8_t G;
+	uint8_t B;
+	uint8_t R;
+	uint8_t G;
 
 
-    ColorGrb(uint8_t gray) :
-        R(gray), G(gray), B(gray)
-    {
-    };
+	ColorGrb(uint8_t gray) :
+		R(gray), G(gray), B(gray)
+	{
+	};
 
-    ColorGrb() : R(0), G(0), B(0)
-    {
-    };
+	ColorGrb() : R(0), G(0), B(0)
+	{
+	};
 };
 
 struct ColorGrbw
 {
-    uint8_t W;
-    uint8_t B;
-    uint8_t R;
-    uint8_t G;
+	uint8_t W;
+	uint8_t B;
+	uint8_t R;
+	uint8_t G;
 
-    ColorGrbw(uint8_t gray) :
-        R(gray), G(gray), B(gray), W(gray)
-    {
-    };
+	ColorGrbw(uint8_t gray) :
+		R(gray), G(gray), B(gray), W(gray)
+	{
+	};
 
-    ColorGrbw() : R(0), G(0), B(0), W(0)
-    {
-    };
+	ColorGrbw() : R(0), G(0), B(0), W(0)
+	{
+	};
 
-    static bool isAlignedTo24()
-    {
-        return false;
-    };
+	static bool isAlignedTo24()
+	{
+		return false;
+	};
 };
 
 struct ColorDotstartBgr
 {
-    uint8_t brightness;
-    uint8_t B;
-    uint8_t G;
-    uint8_t R;
+	uint8_t brightness;
+	uint8_t B;
+	uint8_t G;
+	uint8_t R;
 
-    ColorDotstartBgr(uint8_t gray) :
-        R(gray), G(gray), B(gray), brightness(gray | 0b11100000)
-    {
-    };
+	ColorDotstartBgr(uint8_t gray) :
+		R(gray), G(gray), B(gray), brightness(gray | 0b11100000)
+	{
+	};
 
-    ColorDotstartBgr() : R(0), G(0), B(0), brightness(0xff)
-    {
-    };
+	ColorDotstartBgr() : R(0), G(0), B(0), brightness(0xff)
+	{
+	};
 };
 
 class LedDriver
 {
-    protected:
+	protected:
 
-    int ledsNumber;
-    int pin;
-    int clockPin;
-    int dmaSize;
-    uint8_t* buffer;
-    uint8_t* dma;
+	int ledsNumber;
+	int pin;
+	int clockPin;
+	int dmaSize;
+	uint8_t* buffer;
+	uint8_t* dma;
 
-    public:
+	public:
 
-    LedDriver(int _ledsNumber, int _pin, int _dmaSize): LedDriver(_ledsNumber, _pin, 0, _dmaSize)
-    {
+	LedDriver(int _ledsNumber, int _pin, int _dmaSize): LedDriver(_ledsNumber, _pin, 0, _dmaSize)
+	{
 
-    }
+	}
 
-    LedDriver(int _ledsNumber, int _pin, int _clockPin, int _dmaSize)
-    {
-        LedDriverDmaReceiver = this;
-        ledsNumber = _ledsNumber;
-        pin = _pin;
-        clockPin = _clockPin;
-        dmaSize = _dmaSize;
-        if (dmaSize % 4)
-            dmaSize += (4 - (_dmaSize % 4));
-        buffer = reinterpret_cast<uint8_t*>(calloc(dmaSize, 1));
-        dma = reinterpret_cast<uint8_t*>(calloc(dmaSize, 1));
-    }
+	LedDriver(int _ledsNumber, int _pin, int _clockPin, int _dmaSize)
+	{
+		LedDriverDmaReceiver = this;
+		ledsNumber = _ledsNumber;
+		pin = _pin;
+		clockPin = _clockPin;
+		dmaSize = _dmaSize;
+		if (dmaSize % 4)
+			dmaSize += (4 - (_dmaSize % 4));
+		buffer = reinterpret_cast<uint8_t*>(calloc(dmaSize, 1));
+		dma = reinterpret_cast<uint8_t*>(calloc(dmaSize, 1));
+	}
 
-    ~LedDriver()
-    {
-        free(buffer);
-        free(dma);
-        if (LedDriverDmaReceiver == this)
-            LedDriverDmaReceiver = nullptr;
-    }
+	~LedDriver()
+	{
+		free(buffer);
+		free(dma);
+		if (LedDriverDmaReceiver == this)
+			LedDriverDmaReceiver = nullptr;
+	}
 
-    static LedDriver* LedDriverDmaReceiver;
+	static LedDriver* LedDriverDmaReceiver;
 };
 
 LedDriver* LedDriver::LedDriverDmaReceiver = nullptr;
 
 class DmaClient
 {
-    protected:
+	protected:
 
-    PIO selectedPIO;
-    uint stateIndex;
+	PIO selectedPIO;
+	uint stateIndex;
 
-    static uint PICO_DMA_CHANNEL;
-    static volatile uint64_t lastRenderTime;
-    static volatile bool isDmaBusy;
+	static uint PICO_DMA_CHANNEL;
+	static volatile uint64_t lastRenderTime;
+	static volatile bool isDmaBusy;
 
 
-    DmaClient()
-    {
-        PICO_DMA_CHANNEL = dma_claim_unused_channel(true);
-        isDmaBusy = false;
-        lastRenderTime = 0;
-    };
+	DmaClient()
+	{
+		PICO_DMA_CHANNEL = dma_claim_unused_channel(true);
+		isDmaBusy = false;
+		lastRenderTime = 0;
+	};
 
-    ~DmaClient()
-    {
-        for(int i = 0; i < 10 && isDmaBusy; i++)
-            busy_wait_us(500);
+	~DmaClient()
+	{
+		for(int i = 0; i < 10 && isDmaBusy; i++)
+			busy_wait_us(500);
 
-        dma_channel_abort(PICO_DMA_CHANNEL);
-        dma_channel_set_irq0_enabled(PICO_DMA_CHANNEL, false);
-        irq_set_enabled(DMA_IRQ_0, false);
+		dma_channel_abort(PICO_DMA_CHANNEL);
+		dma_channel_set_irq0_enabled(PICO_DMA_CHANNEL, false);
+		irq_set_enabled(DMA_IRQ_0, false);
 
-        dma_channel_unclaim(PICO_DMA_CHANNEL);
-    };
+		dma_channel_unclaim(PICO_DMA_CHANNEL);
+	};
 
-    void dmaConfigure(PIO _selectedPIO, uint _sm)
-    {
-        selectedPIO = _selectedPIO;
-        stateIndex = _sm;
-    };
+	void dmaConfigure(PIO _selectedPIO, uint _sm)
+	{
+		selectedPIO = _selectedPIO;
+		stateIndex = _sm;
+	};
 
-    void initDmaPio(uint dataLenDword32)
-    {
-        dma_channel_config dmaConfig = dma_channel_get_default_config(PICO_DMA_CHANNEL);
-        channel_config_set_dreq(&dmaConfig, pio_get_dreq(selectedPIO, stateIndex, true));
-        channel_config_set_transfer_data_size(&dmaConfig, DMA_SIZE_32);
-        channel_config_set_read_increment(&dmaConfig, true);
-        dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig, &selectedPIO->txf[stateIndex], NULL, dataLenDword32, false);
+	void initDmaPio(uint dataLenDword32)
+	{
+		dma_channel_config dmaConfig = dma_channel_get_default_config(PICO_DMA_CHANNEL);
+		channel_config_set_dreq(&dmaConfig, pio_get_dreq(selectedPIO, stateIndex, true));
+		channel_config_set_transfer_data_size(&dmaConfig, DMA_SIZE_32);
+		channel_config_set_read_increment(&dmaConfig, true);
+		dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig, &selectedPIO->txf[stateIndex], NULL, dataLenDword32, false);
 
-        assignDmaIrq();
-    };
+		assignDmaIrq();
+	};
 
-    void initDmaSpi(spi_inst_t* _spi, uint dataLenByte8)
-    {
-        dma_channel_config dmaConfig = dma_channel_get_default_config(PICO_DMA_CHANNEL);
-        channel_config_set_transfer_data_size(&dmaConfig, DMA_SIZE_8);
-        channel_config_set_dreq(&dmaConfig, spi_get_dreq(_spi, true));
-        dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig,&spi_get_hw(_spi)->dr, NULL, dataLenByte8, false);
+	void initDmaSpi(spi_inst_t* _spi, uint dataLenByte8)
+	{
+		dma_channel_config dmaConfig = dma_channel_get_default_config(PICO_DMA_CHANNEL);
+		channel_config_set_transfer_data_size(&dmaConfig, DMA_SIZE_8);
+		channel_config_set_dreq(&dmaConfig, spi_get_dreq(_spi, true));
+		dma_channel_configure(PICO_DMA_CHANNEL, &dmaConfig,&spi_get_hw(_spi)->dr, NULL, dataLenByte8, false);
 
-        assignDmaIrq();
-    };
+		assignDmaIrq();
+	};
 
-    void assignDmaIrq()
-    {
-        irq_set_exclusive_handler(DMA_IRQ_0, dmaFinishReceiver);
-        dma_channel_set_irq0_enabled(PICO_DMA_CHANNEL, true);
-        irq_set_enabled(DMA_IRQ_0, true);
-    };
+	void assignDmaIrq()
+	{
+		irq_set_exclusive_handler(DMA_IRQ_0, dmaFinishReceiver);
+		dma_channel_set_irq0_enabled(PICO_DMA_CHANNEL, true);
+		irq_set_enabled(DMA_IRQ_0, true);
+	};
 
-    public:
+	public:
 
-    bool isReadyBlocking()
-    {
-        int wait = 200;
-        while(isDmaBusy && wait-- > 0)
-            busy_wait_us(50);
+	bool isReadyBlocking()
+	{
+		int wait = 200;
+		while(isDmaBusy && wait-- > 0)
+			busy_wait_us(50);
 
-        return !isDmaBusy;
-    }
+		return !isDmaBusy;
+	}
 
-    bool isReady()
-    {
-        return !isDmaBusy;
-    }
+	bool isReady()
+	{
+		return !isDmaBusy;
+	}
 
-    static void dmaFinishReceiver()
-    {
-        if (dma_hw->ints0 & (1u<<DmaClient::PICO_DMA_CHANNEL))
-        {
-            dma_hw->ints0 = (1u<<DmaClient::PICO_DMA_CHANNEL);
+	static void dmaFinishReceiver()
+	{
+		if (dma_hw->ints0 & (1u<<DmaClient::PICO_DMA_CHANNEL))
+		{
+			dma_hw->ints0 = (1u<<DmaClient::PICO_DMA_CHANNEL);
 
-            lastRenderTime = time_us_64();
-            isDmaBusy = false;
-        }
-    }
+			lastRenderTime = time_us_64();
+			isDmaBusy = false;
+		}
+	}
 };
 
 class Neopixel : public LedDriver, public DmaClient
 {
 
-    uint64_t resetTime;
+	uint64_t resetTime;
 
-    friend class NeopixelParallel;
+	friend class NeopixelParallel;
 
-    public:
-    Neopixel(int lanes, uint64_t _resetTime, int _ledsNumber, int _pin, int _dmaSize, bool alignTo24 = false):
-            LedDriver(_ledsNumber, _pin, _dmaSize)
-    {
-        pio_sm_config smConfig;
-        uint programAddress;
+	public:
+	Neopixel(int lanes, uint64_t _resetTime, int _ledsNumber, int _pin, int _dmaSize, bool alignTo24 = false):
+			LedDriver(_ledsNumber, _pin, _dmaSize)
+	{
+		pio_sm_config smConfig;
+		uint programAddress;
 
-        dmaConfigure(pio0, 0);
-        resetTime = _resetTime;
+		dmaConfigure(pio0, 0);
+		resetTime = _resetTime;
 
-        if (lanes >= 1)
-        {
-            programAddress = pio_add_program(selectedPIO,  &neopixel_parallel_program);
-            for(uint i=_pin; i<_pin + lanes; i++){
-                pio_gpio_init(selectedPIO, i);
-            }
-            smConfig = neopixel_parallel_program_get_default_config(programAddress);
-            sm_config_set_out_pins(&smConfig, _pin, lanes);
-            sm_config_set_set_pins(&smConfig, _pin, lanes);
-        }
-        else
-        {
-            programAddress = pio_add_program(selectedPIO,  &neopixel_program);
-            pio_gpio_init(selectedPIO, _pin);
-            smConfig = neopixel_program_get_default_config(programAddress);
-            sm_config_set_sideset_pins(&smConfig, _pin);
-        }
+		if (lanes >= 1)
+		{
+			programAddress = pio_add_program(selectedPIO,  &neopixel_parallel_program);
+			for(uint i=_pin; i<_pin + lanes; i++){
+				pio_gpio_init(selectedPIO, i);
+			}
+			smConfig = neopixel_parallel_program_get_default_config(programAddress);
+			sm_config_set_out_pins(&smConfig, _pin, lanes);
+			sm_config_set_set_pins(&smConfig, _pin, lanes);
+		}
+		else
+		{
+			programAddress = pio_add_program(selectedPIO,  &neopixel_program);
+			pio_gpio_init(selectedPIO, _pin);
+			smConfig = neopixel_program_get_default_config(programAddress);
+			sm_config_set_sideset_pins(&smConfig, _pin);
+		}
 
-        pio_sm_set_consecutive_pindirs(selectedPIO, stateIndex, _pin, std::max(lanes, 1), true);
-        sm_config_set_out_shift(&smConfig, false, true, (alignTo24) ? 24: 32);
-        sm_config_set_fifo_join(&smConfig, PIO_FIFO_JOIN_TX);
-        float div = clock_get_hz(clk_sys) / (800000 * 12);
-        sm_config_set_clkdiv(&smConfig, div);
-        pio_sm_init(selectedPIO, stateIndex, programAddress, &smConfig);
-        pio_sm_set_enabled(selectedPIO, stateIndex, true);
+		pio_sm_set_consecutive_pindirs(selectedPIO, stateIndex, _pin, std::max(lanes, 1), true);
+		sm_config_set_out_shift(&smConfig, false, true, (alignTo24) ? 24: 32);
+		sm_config_set_fifo_join(&smConfig, PIO_FIFO_JOIN_TX);
+		float div = clock_get_hz(clk_sys) / (800000 * 12);
+		sm_config_set_clkdiv(&smConfig, div);
+		pio_sm_init(selectedPIO, stateIndex, programAddress, &smConfig);
+		pio_sm_set_enabled(selectedPIO, stateIndex, true);
 
-        initDmaPio(dmaSize / 4);
-    }
+		initDmaPio(dmaSize / 4);
+	}
 
-    uint8_t* getBufferMemory()
-    {
-        return buffer;
-    }
+	uint8_t* getBufferMemory()
+	{
+		return buffer;
+	}
 
-    protected:
+	protected:
 
-    void renderDma(bool resetBuffer)
-    {
-        if (isDmaBusy)
-            return;
+	void renderDma(bool resetBuffer)
+	{
+		if (isDmaBusy)
+			return;
 
-        isDmaBusy = true;
+		isDmaBusy = true;
 
-        uint64_t currentTime = time_us_64();
-        if (currentTime < resetTime + lastRenderTime)
-            busy_wait_us(std::min(resetTime + lastRenderTime - currentTime, resetTime));
+		uint64_t currentTime = time_us_64();
+		if (currentTime < resetTime + lastRenderTime)
+			busy_wait_us(std::min(resetTime + lastRenderTime - currentTime, resetTime));
 
-        memcpy(dma, buffer, dmaSize);
+		memcpy(dma, buffer, dmaSize);
 
-        dma_channel_set_read_addr(PICO_DMA_CHANNEL, dma, true);
+		dma_channel_set_read_addr(PICO_DMA_CHANNEL, dma, true);
 
-        if (resetBuffer)
-            memset(buffer, 0, dmaSize);
-    }
+		if (resetBuffer)
+			memset(buffer, 0, dmaSize);
+	}
 };
 
 template<int RESET_TIME, typename colorData>
 class NeopixelType : public Neopixel
 {
-    public:
+	public:
 
-    NeopixelType(int _ledsNumber, int _pin) : Neopixel(0, RESET_TIME, _ledsNumber, _pin, _ledsNumber * sizeof(colorData), colorData::isAlignedTo24())
-    {
-    }
+	NeopixelType(int _ledsNumber, int _pin) : Neopixel(0, RESET_TIME, _ledsNumber, _pin, _ledsNumber * sizeof(colorData), colorData::isAlignedTo24())
+	{
+	}
 
-    void SetPixel(int index, colorData color)
-    {
-        if (index >= ledsNumber)
-            return;
+	void SetPixel(int index, colorData color)
+	{
+		if (index >= ledsNumber)
+			return;
 
-        *(reinterpret_cast<colorData*>(buffer)+index) = color;
-    }
+		*(reinterpret_cast<colorData*>(buffer)+index) = color;
+	}
 
-    void renderSingleLane()
-    {
-        renderDma(false);
-    }
+	void renderSingleLane()
+	{
+		renderDma(false);
+	}
 };
 
 
 class NeopixelParallel
 {
-    static Neopixel *muxer;
-    static int instances;
+	static Neopixel *muxer;
+	static int instances;
 
-    protected:
-    static int maxLeds;
-    const uint8_t myLaneMask;
-    static uint8_t* buffer;
+	protected:
+	static int maxLeds;
+	const uint8_t myLaneMask;
+	static uint8_t* buffer;
 
-    public:
+	public:
 
-    NeopixelParallel(size_t pixelSize, uint64_t _resetTime, int _ledsNumber, int _pin):
-                    myLaneMask(1 << (instances++))
-    {
-        maxLeds = std::max(maxLeds, _ledsNumber);
+	NeopixelParallel(size_t pixelSize, uint64_t _resetTime, int _ledsNumber, int _pin):
+					myLaneMask(1 << (instances++))
+	{
+		maxLeds = std::max(maxLeds, _ledsNumber);
 
-        delete muxer;
-        muxer = new Neopixel(instances, _resetTime, maxLeds, _pin, maxLeds * 8 * pixelSize );
-        buffer = muxer->getBufferMemory();
-    }
+		delete muxer;
+		muxer = new Neopixel(instances, _resetTime, maxLeds, _pin, maxLeds * 8 * pixelSize );
+		buffer = muxer->getBufferMemory();
+	}
 
-    ~NeopixelParallel()
-    {
-        if (instances > 0)
-            instances--;
+	~NeopixelParallel()
+	{
+		if (instances > 0)
+			instances--;
 
-        if (instances == 0)
-        {
-            delete muxer;
-            muxer = nullptr;
-            buffer = nullptr;
-            maxLeds = 0;
-        }
-    }
+		if (instances == 0)
+		{
+			delete muxer;
+			muxer = nullptr;
+			buffer = nullptr;
+			maxLeds = 0;
+		}
+	}
 
-    bool isReadyBlocking()
-    {
-        return muxer->isReadyBlocking();
-    }
+	bool isReadyBlocking()
+	{
+		return muxer->isReadyBlocking();
+	}
 
-    bool isReady()
-    {
-        return muxer->isReady();
-    }
+	bool isReady()
+	{
+		return muxer->isReady();
+	}
 
-    void renderAllLanes()
-    {
-        muxer->renderDma(true);
-    }
+	void renderAllLanes()
+	{
+		muxer->renderDma(true);
+	}
 };
 
 template<int RESET_TIME, typename colorData>
 class NeopixelParallelType : public NeopixelParallel
 {
-    uint32_t lut[16];
+	uint32_t lut[16];
 
-    public:
+	public:
 
-    NeopixelParallelType(int _ledsNumber, int _basePinForLanes) : NeopixelParallel(sizeof(colorData), RESET_TIME,
-                                                        _ledsNumber, _basePinForLanes)
-    {
-        for (uint8_t a = 0; a < 16; a++)
-        {
-            uint8_t* target = reinterpret_cast<uint8_t*>(&(lut[a]));
-            for (uint8_t b = 0; b < 4; b++)
-                *(target++) = (uint8_t) ((a & (0b00000001 << b)) ? myLaneMask : 0);
-        }
-    }
+	NeopixelParallelType(int _ledsNumber, int _basePinForLanes) : NeopixelParallel(sizeof(colorData), RESET_TIME,
+														_ledsNumber, _basePinForLanes)
+	{
+		for (uint8_t a = 0; a < 16; a++)
+		{
+			uint8_t* target = reinterpret_cast<uint8_t*>(&(lut[a]));
+			for (uint8_t b = 0; b < 4; b++)
+				*(target++) = (uint8_t) ((a & (0b00000001 << b)) ? myLaneMask : 0);
+		}
+	}
 
-    void SetPixel(int index, colorData color)
-    {
-        if (index >= maxLeds)
-            return;
+	void SetPixel(int index, colorData color)
+	{
+		if (index >= maxLeds)
+			return;
 
-        uint8_t* source = reinterpret_cast<uint8_t*>(&color);
-        uint32_t* target = reinterpret_cast<uint32_t*>(&(buffer[(index + 1) * 8 * sizeof(colorData)]));
+		uint8_t* source = reinterpret_cast<uint8_t*>(&color);
+		uint32_t* target = reinterpret_cast<uint32_t*>(&(buffer[(index + 1) * 8 * sizeof(colorData)]));
 
-        for(int i = 0; i < sizeof(colorData); i++)
-        {
-            *(--target) |= lut[ *(source) & 0b00001111];
-            *(--target) |= lut[ *(source++) >> 4];
-        }
-    }
+		for(int i = 0; i < sizeof(colorData); i++)
+		{
+			*(--target) |= lut[ *(source) & 0b00001111];
+			*(--target) |= lut[ *(source++) >> 4];
+		}
+	}
 };
 
 class Dotstar : public LedDriver, public DmaClient
 {
-    uint64_t resetTime;
+	uint64_t resetTime;
 
-    friend class NeopixelParallel;
+	friend class NeopixelParallel;
 
-    public:
-    Dotstar(uint64_t _resetTime, int _ledsNumber, spi_inst_t* _spi, uint32_t _datapin, uint32_t _clockpin, int _dmaSize):
-            LedDriver(_ledsNumber, _datapin, _clockpin, _dmaSize)
-    {
-        dmaConfigure(pio0, 0);
-        resetTime = _resetTime;
+	public:
+	Dotstar(uint64_t _resetTime, int _ledsNumber, spi_inst_t* _spi, uint32_t _datapin, uint32_t _clockpin, int _dmaSize):
+			LedDriver(_ledsNumber, _datapin, _clockpin, _dmaSize)
+	{
+		dmaConfigure(pio0, 0);
+		resetTime = _resetTime;
 
-        spi_init(_spi, 10000000);        
-        gpio_set_function(_clockpin, GPIO_FUNC_SPI);
-        gpio_set_function(_datapin, GPIO_FUNC_SPI);
-        bi_decl(bi_4pins_with_func(PICO_DEFAULT_SPI_RX_PIN, _datapin, _clockpin, PICO_DEFAULT_SPI_CSN_PIN, GPIO_FUNC_SPI));
+		spi_init(_spi, 10000000);        
+		gpio_set_function(_clockpin, GPIO_FUNC_SPI);
+		gpio_set_function(_datapin, GPIO_FUNC_SPI);
+		bi_decl(bi_4pins_with_func(PICO_DEFAULT_SPI_RX_PIN, _datapin, _clockpin, PICO_DEFAULT_SPI_CSN_PIN, GPIO_FUNC_SPI));
 
-        initDmaSpi(_spi, _dmaSize);
-    }
+		initDmaSpi(_spi, _dmaSize);
+	}
 
-    uint8_t* getBufferMemory()
-    {
-        return buffer;
-    }
+	uint8_t* getBufferMemory()
+	{
+		return buffer;
+	}
 
-    protected:
+	protected:
 
-    void renderDma()
-    {
-        if (isDmaBusy)
-            return;
+	void renderDma()
+	{
+		if (isDmaBusy)
+			return;
 
-        isDmaBusy = true;
+		isDmaBusy = true;
 
-        uint64_t currentTime = time_us_64();
-        if (currentTime < resetTime + lastRenderTime)
-            busy_wait_us(std::min(resetTime + lastRenderTime - currentTime, resetTime));
+		uint64_t currentTime = time_us_64();
+		if (currentTime < resetTime + lastRenderTime)
+			busy_wait_us(std::min(resetTime + lastRenderTime - currentTime, resetTime));
 
-        memcpy(dma, buffer, dmaSize);
+		memcpy(dma, buffer, dmaSize);
 
-        dma_channel_set_read_addr(PICO_DMA_CHANNEL, dma, true);
-    }
+		dma_channel_set_read_addr(PICO_DMA_CHANNEL, dma, true);
+	}
 };
 
 template<int RESET_TIME, typename colorData>
 class DotstarType : public Dotstar
 {
-    public:
+	public:
 
-    DotstarType(int _ledsNumber, spi_inst_t* _spi, int _dataPin, int _clockPin) : 
-        Dotstar(RESET_TIME, _ledsNumber, _spi, _dataPin, _clockPin, (_ledsNumber + 2) * sizeof(colorData))
-    {
-    }
+	DotstarType(int _ledsNumber, spi_inst_t* _spi, int _dataPin, int _clockPin) : 
+		Dotstar(RESET_TIME, _ledsNumber, _spi, _dataPin, _clockPin, (_ledsNumber + 2) * sizeof(colorData))
+	{
+	}
 
-    void SetPixel(int index, colorData color)
-    {
-        if (index >= ledsNumber)
-            return;
+	void SetPixel(int index, colorData color)
+	{
+		if (index >= ledsNumber)
+			return;
 
-        *(reinterpret_cast<colorData*>(buffer)+index+1) = color;
-    }
+		*(reinterpret_cast<colorData*>(buffer)+index+1) = color;
+	}
 
-    void renderSingleLane()
-    {
-        memset(buffer,0 ,4);
-        *(reinterpret_cast<colorData*>(buffer)+ledsNumber+1) = colorData(0xff);
-        renderDma();
-    }
+	void renderSingleLane()
+	{
+		memset(buffer,0 ,4);
+		*(reinterpret_cast<colorData*>(buffer)+ledsNumber+1) = colorData(0xff);
+		renderDma();
+	}
 };
 
 Neopixel* NeopixelParallel::muxer = nullptr;

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -72,6 +72,7 @@
 
 #ifdef SPILED_APA102
 	#define LED_DRIVER apa102
+    #pragma message(VAR_NAME_VALUE(SPI_INTERFACE))
 #endif
 
 	#pragma message(VAR_NAME_VALUE(DATA_PIN))

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -72,7 +72,7 @@
 
 #ifdef SPILED_APA102
 	#define LED_DRIVER apa102
-    #pragma message(VAR_NAME_VALUE(SPI_INTERFACE))
+	#pragma message(VAR_NAME_VALUE(SPI_INTERFACE))
 #endif
 
 	#pragma message(VAR_NAME_VALUE(DATA_PIN))


### PR DESCRIPTION
Default SPI pinout changed.
Add new option to select rp2040 SPI interface (spi0 or spi1) in the build configuration.
Possible SPI pinouts clarified: hardware SPI is only available for selected pins depending on the SPI interface.