### PR TITLE
Workaround for some rp2040 boards not booting (e.g. Adafruit)

### DIFF
--- a/.github/workflows/push-master.yml
+++ b/.github/workflows/push-master.yml
@@ -53,7 +53,7 @@ jobs:
         rm ../firmware/*
         echo "Neopixel is using GPIO16(OUTPUT_DATA_PIN) on output 0." > ../firmware/Firmwares_for_Adafruit_Feather_RP2040_Scorpio.txt
         echo "SPI is using spi0 interface pins: GPIO19(OUTPUT_SPI_DATA_PIN) and GPIO18(OUTPUT_SPI_CLOCK_PIN) on output 3 and 2 respectively." >> ../firmware/Firmwares_for_Adafruit_Feather_RP2040_Scorpio.txt
-        cmake -DOVERRIDE_DATA_PIN=16 -DOVERRIDE_SPI_DATA_PIN=19 -DOVERRIDE_SPI_CLOCK_PIN=18 -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOVERRIDE_BOOT_WORKAROUND=ON -DOVERRIDE_DATA_PIN=16 -DOVERRIDE_SPI_DATA_PIN=19 -DOVERRIDE_SPI_CLOCK_PIN=18 -DCMAKE_BUILD_TYPE=Release ..
         cmake --build .
         zip -j ../firmware/Adafruit_Feather_RP2040_Scorpio.zip ../firmware/*
 
@@ -73,7 +73,7 @@ jobs:
         rm *.*
         rm ../firmware/*
         echo "Neopixel is using GPIO14(OUTPUT_DATA_PIN) on output 5." > ../firmware/Firmwares_for_Adafruit_ItsyBitsy_2040.txt
-        cmake -DOVERRIDE_DATA_PIN=14 -DCMAKE_BUILD_TYPE=Release ..
+        cmake -DOVERRIDE_BOOT_WORKAROUND=ON -DOVERRIDE_DATA_PIN=14 -DCMAKE_BUILD_TYPE=Release ..
         cmake --build .
         rm ../firmware/*_Spi.uf2
         zip -j ../firmware/Adafruit_ItsyBitsy_2040.zip ../firmware/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 sdk/pico
 build/*
 generated/
-firmwares/
+firmware/
 
 # User-specific files
 *.rsuser

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 # User configuration section starts here
 
+# Some boards, such as the first Adafruit revisions, may have trouble booting properly
+# due to bad componets used in the design.
+# Turn this setting to ON if your rp2040 is not detected after firmware upload and reset
+set(BOOT_WORKAROUND OFF)
+
 # Default output data pin for the non-SPI LED strips (only for sk6812/ws2812b)
 set(OUTPUT_DATA_PIN 2)
 
@@ -78,17 +83,26 @@ if (OVERRIDE_SPI_INTERFACE)
 	message( STATUS "${YellowColor}Overriding SPI Interface: ${OUTPUT_SPI_INTERFACE}${ColorReset}")
 endif()
 
+if (OVERRIDE_BOOT_WORKAROUND)
+	set(BOOT_WORKAROUND ${OVERRIDE_BOOT_WORKAROUND})
+	message( STATUS "${YellowColor}Overriding boot workaround: ${BOOT_WORKAROUND}${ColorReset}")
+endif()
+
 message( STATUS "---------------------------")
 message( STATUS "Neopixel Data GPIO: ${GreenColor}${OUTPUT_DATA_PIN}${ColorReset}")
 message( STATUS "SPI Data GPIO: ${GreenColor}${OUTPUT_SPI_DATA_PIN}${ColorReset}")
 message( STATUS "SPI Clock GPIO: ${GreenColor}${OUTPUT_SPI_CLOCK_PIN}${ColorReset}")
 message( STATUS "SPI Interface: ${GreenColor}${OUTPUT_SPI_INTERFACE}${ColorReset}")
+message( STATUS "Boot workaround: ${GreenColor}${BOOT_WORKAROUND}${ColorReset}")
 message( STATUS "---------------------------")
 
 add_compile_options(-ftrack-macro-expansion=0 -fno-diagnostics-show-caret -fdiagnostics-color=auto)
 
 macro(HyperSerialPicoTarget HyperSerialPicoTargetName)
     add_executable(${HyperSerialPicoTargetName} ${CMAKE_SOURCE_DIR}/source/main.cpp)
+    if (BOOT_WORKAROUND)
+        target_compile_definitions(${HyperSerialPicoTargetName} PUBLIC -DBOOT_WORKAROUND -DPICO_XOSC_STARTUP_DELAY_MULTIPLIER=64)
+    endif()
     target_include_directories(${HyperSerialPicoTargetName} PRIVATE ${HyperSerialPicoCompanionIncludes})
     target_link_libraries(${HyperSerialPicoTargetName} ${HyperSerialPicoCompanionLibs})
     pico_add_extra_outputs(${HyperSerialPicoTargetName})

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -51,6 +51,12 @@
 #define _XSTR2(x,y) _STR(x) _STR(y)
 #define VAR_NAME_VALUE2(var) #var " = " _XSTR2(var)
 
+#if defined(BOOT_WORKAROUND) && defined(PICO_XOSC_STARTUP_DELAY_MULTIPLIER)
+	#pragma message("Enabling boot workaround")
+	#pragma message(VAR_NAME_VALUE(PICO_XOSC_STARTUP_DELAY_MULTIPLIER))
+#endif
+
+
 #ifdef NEOPIXEL_RGBW
 	#pragma message(VAR_NAME_VALUE(NEOPIXEL_RGBW))
 #endif


### PR DESCRIPTION
Some boards, such as the first Adafruit revisions, may have trouble booting properly due to bad components used in the design.
Read more here: https://github.com/raspberrypi/pico-sdk/pull/457
This PR adds `BOOT_WORKAROUND` option to CMakeLists.txt that user can enable (set to ON) to workaround the problem.
Official releases of HyperSerialPico firmware packages for Adafruit ItsyBitsy and Scorpio will be compiled with this option enabled.