### PR TITLE
Add direct 32-bit rendering for RGBW with dithering

### DIFF
--- a/include/framestate.h
+++ b/include/framestate.h
@@ -35,6 +35,7 @@
 enum class AwaProtocol
 {
 	HEADER_A,
+	HEADER_W,	
 	HEADER_w,
 	HEADER_a,
 	HEADER_HI,
@@ -47,6 +48,7 @@ enum class AwaProtocol
 	RED,
 	GREEN,
 	BLUE,
+	EXTRA_COLOR_BYTE_4,	
 	FLETCHER1,
 	FLETCHER2,
 	FLETCHER_EXT
@@ -60,6 +62,7 @@ class
 {
 	volatile AwaProtocol state = AwaProtocol::HEADER_A;
 	bool protocolVersion2 = false;
+	bool protocolVersion3 = false;	
 	uint8_t CRC = 0;
 	uint16_t count = 0;
 	uint16_t currentLed = 0;
@@ -169,6 +172,27 @@ class
 		{
 			return protocolVersion2;
 		}
+
+		/**
+		 * @brief Set if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @param newVer
+		 */
+		inline void setProtocolVersion3(bool newVer)
+		{
+			protocolVersion3 = newVer;
+		}
+
+		/**
+		 * @brief Verify if frame protocol version 3 (direct 32bit mode)
+		 *
+		 * @return true
+		 * @return false
+		 */
+		inline bool isProtocolVersion3() const
+		{
+			return protocolVersion3;
+		}		
 
 		/**
 		 * @brief  Set new AWA frame state

--- a/include/leds.h
+++ b/include/leds.h
@@ -140,17 +140,17 @@ struct ColorGrbw
 
 struct ColorDotstartBgr
 {
-	uint8_t brightness;
+	uint8_t Brightness;
 	uint8_t B;
 	uint8_t G;
 	uint8_t R;
 
 	ColorDotstartBgr(uint8_t gray) :
-		R(gray), G(gray), B(gray), brightness(gray | 0b11100000)
+		R(gray), G(gray), B(gray), Brightness(gray | 0b11100000)
 	{
 	};
 
-	ColorDotstartBgr() : R(0), G(0), B(0), brightness(0xff)
+	ColorDotstartBgr() : R(0), G(0), B(0), Brightness(0xff)
 	{
 	};
 };

--- a/include/main.h
+++ b/include/main.h
@@ -29,7 +29,7 @@
 #define MAIN_H
 
 #define MAX_BUFFER (3013 * 3 + 1)
-#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 9.\r\n"
+#define HELLO_MESSAGE "\r\nWelcome!\r\nAwa driver 11.\r\n"
 
 #include "calibration.h"
 #include "statistics.h"
@@ -81,6 +81,7 @@ void processData()
 		case AwaProtocol::HEADER_A:
 			// assume it's protocol version 1, verify it later
 			frameState.setProtocolVersion2(false);
+			frameState.setProtocolVersion3(false);			
 			if (input == 'A')
 				frameState.setState(AwaProtocol::HEADER_w);
 			break;
@@ -88,6 +89,20 @@ void processData()
 		case AwaProtocol::HEADER_w:
 			if (input == 'w')
 				frameState.setState(AwaProtocol::HEADER_a);
+#if defined(NEOPIXEL_RGBW) || defined(SPILED_APA102)
+			else if (input == 'W')
+				frameState.setState(AwaProtocol::HEADER_W);
+#endif
+			else
+				frameState.setState(AwaProtocol::HEADER_A);
+			break;
+		case AwaProtocol::HEADER_W:
+			// detect protocol version 3
+			if (input == 'a')			
+			{
+				frameState.setState(AwaProtocol::HEADER_HI);
+				frameState.setProtocolVersion3(true);
+			}				
 			else
 				frameState.setState(AwaProtocol::HEADER_A);
 			break;
@@ -167,9 +182,37 @@ void processData()
 			frameState.setState(AwaProtocol::BLUE);
 			break;
 
+		case AwaProtocol::EXTRA_COLOR_BYTE_4:
+			#ifdef NEOPIXEL_RGBW
+				frameState.color.W = input;
+			#elif defined(SPILED_APA102)
+				frameState.color.Brightness = input;
+			#endif
+			frameState.addFletcher(input);
+
+			if (base.setStripPixel(frameState.getCurrentLedIndex(), frameState.color))
+			{
+				frameState.setState(AwaProtocol::RED);
+			}
+			else
+			{
+				frameState.setState(AwaProtocol::FLETCHER1);
+			}
+			break;			
+
 		case AwaProtocol::BLUE:
 			frameState.color.B = input;
 			frameState.addFletcher(input);
+
+			if (frameState.isProtocolVersion3())
+			{
+				frameState.setState(AwaProtocol::EXTRA_COLOR_BYTE_4);
+				break;
+			}
+
+			#if defined(SPILED_APA102)
+				frameState.color.Brightness = 0xFF;
+			#endif
 
 			#ifdef NEOPIXEL_RGBW
 				// calculate RGBW from RGB using provided calibration data


### PR DESCRIPTION
Introduced direct 32-bit mode for the upcoming RGBW mode with dithering, powered by the Infinite Color Engine in HyperHDR.
More: https://github.com/awawa-dev/HyperHDR/wiki/ICE_RGBW